### PR TITLE
KB-6591 | Content portal > How Tos > SPV publisher not able to upload Thumbnail/Resource

### DIFF
--- a/src/utils/whitelistApis.ts
+++ b/src/utils/whitelistApis.ts
@@ -422,6 +422,7 @@ export const API_LIST = {
                 ROLE.MDO_LEADER,
                 ROLE.PROGRAM_COORDINATOR,
                 ROLE.SPV_ADMIN,
+                ROLE.SPV_PUBLISHER
             ],
         },
         '/proxies/v8/v1/content/retire': {


### PR DESCRIPTION

1. Added SPV_PUBLISHER role to API.