### PR TITLE
Added a new public api for designation search

### DIFF
--- a/src/publicApi_v8/publicApiV8.ts
+++ b/src/publicApi_v8/publicApiV8.ts
@@ -21,6 +21,7 @@ const API_END_POINTS = {
   publicAssessmentV5Result: `${CONSTANTS.KONG_API_BASE}/public/assessment/v5/result`,
   publicAssessmentV5Submit: `${CONSTANTS.KONG_API_BASE}/public/assessment/v5/assessment/submit`,
   publicAssessmentV7Result: `${CONSTANTS.KONG_API_BASE}/public/assessment/v7/result`,
+  designationSearch: `${CONSTANTS.KONG_API_BASE}/designation/search`,
 }
 
 publicApiV8.get('/', (_req, res) => {
@@ -146,3 +147,86 @@ publicApiV8.use('/org/v2/list', proxyCreatorRoute(express.Router(), CONSTANTS.KO
 publicApiV8.use('/liveness', (_req, res) => {
     res.status(200).send('ok')
 })
+
+publicApiV8.post('/designation/search', async (req, res) => {
+  let { searchString, pageSize, pageNumber, requestedFields } = req.body;
+
+  // ---- 0. Apply defaults if missing ----
+  pageNumber = Number(pageNumber ?? 0);   // default 0
+  pageSize = Number(pageSize ?? 20);      // default 20
+
+  // ---- Ensure requestedFields is always an array ----
+  if (!Array.isArray(requestedFields)) {
+    requestedFields = [];
+  }
+
+  // ---- 1. Validate searchString ----
+  if (typeof searchString !== 'string') {
+    return res.status(400).json({
+      message: "searchString must be a string"
+    });
+  }
+
+  if (searchString.length < 2 || searchString.length > 50) {
+    return res.status(400).json({
+      message: "searchString length must be between 2 and 50 characters"
+    });
+  }
+
+  const forbiddenPatterns = /[*{}[\]\\]|(\b(AND|OR|NOT)\b)/i;
+  if (forbiddenPatterns.test(searchString)) {
+    return res.status(400).json({
+      message: "Invalid characters in searchString"
+    });
+  }
+
+  // ---- 2. Validate pageSize (1–50) ----
+  if (isNaN(pageSize) || pageSize < 1 || pageSize > 50) {
+    return res.status(400).json({
+      message: "pageSize must be a number between 1 and 50"
+    });
+  }
+
+  // ---- 3. Validate pageNumber (0–10000) ----
+  if (isNaN(pageNumber) || pageNumber < 0 || pageNumber > 10000) {
+    return res.status(400).json({
+      message: "pageNumber must be a number between 0 and 10000"
+    });
+  }
+
+  // ---- Set normalized values back into req.body ----
+  req.body.pageNumber = pageNumber;
+  req.body.pageSize = pageSize;
+  req.body.requestedFields = requestedFields;
+
+  await publicDesignationSearch(req, res);
+})
+
+const publicDesignationSearch = async (req: Request, res: express.Response) => {
+  const reqBody = {
+      filterCriteriaMap: {
+        status:'Active'
+      },
+      pageSize: req.body.pageSize,
+      pageNumber: req.body.pageNumber,
+      searchString: req.body.searchString,
+      requestedFields: req.body.requestedFields,
+  }
+  try {
+    const response = await axios.post(API_END_POINTS.designationSearch, reqBody, {
+      ...axiosRequestConfig,
+      headers: {
+        Authorization: CONSTANTS.SB_API_KEY,
+      },
+    })
+    const resCode = response.data.responseCode
+    if (!resCode || resCode.toLowerCase() !== 'ok') {
+      res.status(400).send(response.data)
+    } else {
+      res.status(200).send(response.data)
+    }
+  } catch (error) {
+    logError(`Failed to get designation list. Error: ${error}`)
+    res.status(500).send('Internal Server Error')
+  }
+}

--- a/src/publicApi_v8/publicApiV8.ts
+++ b/src/publicApi_v8/publicApiV8.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import express from 'express'
+import express, { Request } from 'express'
 import { axiosRequestConfig } from '../configs/request.config'
 import { CONSTANTS } from '../utils/env'
 import { logError } from '../utils/logger'
@@ -12,6 +12,7 @@ const puppeteer = require('puppeteer')
 export const publicApiV8 = express.Router()
 
 const API_END_POINTS = {
+  designationSearch: `${CONSTANTS.KONG_API_BASE}/designation/search`,
   kongCompositeSearch: `${CONSTANTS.KONG_API_BASE}/composite/v4/search`,
   publicAssessmentV1QuestionList: `${CONSTANTS.KONG_API_BASE}/public/assessment/v1/question/list`,
   publicAssessmentV1Read: `${CONSTANTS.KONG_API_BASE}/public/assessment/v1/read/:id`,
@@ -21,7 +22,6 @@ const API_END_POINTS = {
   publicAssessmentV5Result: `${CONSTANTS.KONG_API_BASE}/public/assessment/v5/result`,
   publicAssessmentV5Submit: `${CONSTANTS.KONG_API_BASE}/public/assessment/v5/assessment/submit`,
   publicAssessmentV7Result: `${CONSTANTS.KONG_API_BASE}/public/assessment/v7/result`,
-  designationSearch: `${CONSTANTS.KONG_API_BASE}/designation/search`,
 }
 
 publicApiV8.get('/', (_req, res) => {
@@ -149,68 +149,66 @@ publicApiV8.use('/liveness', (_req, res) => {
 })
 
 publicApiV8.post('/designation/search', async (req, res) => {
-  let { searchString, pageSize, pageNumber, requestedFields } = req.body;
+  const { searchString } = req.body
+  let { pageSize, pageNumber, requestedFields } = req.body
 
   // ---- 0. Apply defaults if missing ----
-  pageNumber = Number(pageNumber ?? 0);   // default 0
-  pageSize = Number(pageSize ?? 20);      // default 20
-
+  pageNumber = Number(pageNumber !== undefined && pageNumber !== null ? pageNumber : 0)
+  pageSize = Number(pageSize !== undefined && pageSize !== null ? pageSize : 20)
   // ---- Ensure requestedFields is always an array ----
   if (!Array.isArray(requestedFields)) {
-    requestedFields = [];
+    requestedFields = []
   }
 
   // ---- 1. Validate searchString ----
   if (typeof searchString !== 'string') {
     return res.status(400).json({
-      message: "searchString must be a string"
-    });
+      message: 'searchString must be a string',
+    })
   }
-
   if (searchString.length < 2 || searchString.length > 50) {
     return res.status(400).json({
-      message: "searchString length must be between 2 and 50 characters"
-    });
+      message: 'searchString length must be between 2 and 50 characters',
+    })
+  }
+  const searchQueryStringRegex = new RegExp(CONSTANTS.SEARCH_QUERY_STRING_REGEX, 'i')
+  if (searchQueryStringRegex.test(searchString)) {
+    return res.status(400).json({
+    message: 'Invalid characters in searchString',
+    })
   }
 
-  const forbiddenPatterns = /[*{}[\]\\]|(\b(AND|OR|NOT)\b)/i;
-  if (forbiddenPatterns.test(searchString)) {
+  // ---- 2. Validate pageSize (1–100) ----
+  if (isNaN(pageSize) || pageSize < 1 || pageSize > 100) {
     return res.status(400).json({
-      message: "Invalid characters in searchString"
-    });
-  }
-
-  // ---- 2. Validate pageSize (1–50) ----
-  if (isNaN(pageSize) || pageSize < 1 || pageSize > 50) {
-    return res.status(400).json({
-      message: "pageSize must be a number between 1 and 50"
-    });
+      message: 'pageSize must be a number between 1 and 100',
+    })
   }
 
   // ---- 3. Validate pageNumber (0–10000) ----
   if (isNaN(pageNumber) || pageNumber < 0 || pageNumber > 10000) {
     return res.status(400).json({
-      message: "pageNumber must be a number between 0 and 10000"
-    });
+      message: 'pageNumber must be a number between 0 and 10000',
+    })
   }
 
   // ---- Set normalized values back into req.body ----
-  req.body.pageNumber = pageNumber;
-  req.body.pageSize = pageSize;
-  req.body.requestedFields = requestedFields;
+  req.body.pageNumber = pageNumber
+  req.body.pageSize = pageSize
+  req.body.requestedFields = requestedFields
 
-  await publicDesignationSearch(req, res);
+  return publicDesignationSearch(req, res)
 })
 
 const publicDesignationSearch = async (req: Request, res: express.Response) => {
   const reqBody = {
       filterCriteriaMap: {
-        status:'Active'
+        status: 'Active',
       },
-      pageSize: req.body.pageSize,
       pageNumber: req.body.pageNumber,
-      searchString: req.body.searchString,
+      pageSize: req.body.pageSize,
       requestedFields: req.body.requestedFields,
+      searchString: req.body.searchString,
   }
   try {
     const response = await axios.post(API_END_POINTS.designationSearch, reqBody, {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -208,6 +208,8 @@ export const CONSTANTS = {
   IIM_PORTAL_HOST: env.IIM_PORTAL_HOST || 'https://iiidem-portal.igotkarmayogi.gov.in',
   EC_REDIRECT_PATH: env.EC_REDIRECT_PATH || '/page/custom-home/iiidem',
   IIIDEM_PORTAL_HOST: env.IIIDEM_PORTAL_HOST || 'iiidem.igotkarmayogi.gov.in',
+  SEARCH_QUERY_STRING_REGEX: env.SEARCH_QUERY_STRING_REGEX || '[*{}\\[\\]\\\\]|(\\b(AND|OR|NOT)\\b)',
+
 }
 
 export const RESTRICTED_PYTHON_STMT: string[] = process.env.RESTRICTED_CHARACTERS


### PR DESCRIPTION
Ticket:https://karmayogibharat.atlassian.net/browse/KB-12113

We need to integrate the Designation Search API on the registration page. The existing API requires a cookie, so I created a new proxy public endpoint that does not require a cookie. Additionally, I implemented sufficient validation measures to prevent misuse of the API.