### PR TITLE
Move body parsing after keycloak auth to skip CPU on rejected requests

### DIFF
--- a/src/authoring/authSearch.ts
+++ b/src/authoring/authSearch.ts
@@ -5,6 +5,10 @@ import { AxiosRequestConfig } from './../models/axios-request-config.model'
 import { DEFAULT_META } from './constants/default-meta'
 export const authSearch = express.Router()
 
+// Route-level body parsing — global parsers removed, each router parses its own.
+authSearch.use(express.json({ limit: '50mb' }))
+authSearch.use(express.urlencoded({ extended: false, limit: '50mb' }))
+
 authSearch.all('*', (req, res) => {
   const body = {
     ...(req.body || {}),

--- a/src/authoring/content/index.ts
+++ b/src/authoring/content/index.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { Request, Response, Router } from 'express'
+import express, { Request, Response, Router } from 'express'
 import { axiosRequestConfig } from '../../configs/request.config'
 import { AxiosRequestConfig } from '../../models/axios-request-config.model'
 import { logError} from '../../utils/logger'
@@ -21,6 +21,12 @@ import { searchForOtherLanguage } from './language-search'
 const _ = require('lodash')
 
 export const authApi = Router()
+
+// Route-level body parsing — authApi is mounted without keycloak.protect,
+// so it doesn't get the global body parsers (which run after auth).
+authApi.use(express.json({ limit: '50mb' }))
+authApi.use(express.urlencoded({ extended: false, limit: '50mb' }))
+
 const failedToProcess = 'Failed to process the request. '
 const actionConst = '/action'
 

--- a/src/protectedApi_v8/protectedApiV8.ts
+++ b/src/protectedApi_v8/protectedApiV8.ts
@@ -39,6 +39,11 @@ import { workflowHandlerApi } from './workflow-handler'
 
 export const protectedApiV8 = express.Router()
 
+// Route-level body parsing — runs after keycloak.protect so unauthenticated
+// requests are rejected before spending CPU on JSON deserialization.
+protectedApiV8.use(express.json({ limit: '50mb' }))
+protectedApiV8.use(express.urlencoded({ extended: false, limit: '50mb' }))
+
 protectedApiV8.get('/', (_req, res) => {
   res.json({
     config: CONSTANTS.HTTPS_HOST,

--- a/src/proxies_v8/proxies_v8.ts
+++ b/src/proxies_v8/proxies_v8.ts
@@ -44,6 +44,12 @@ const API_END_POINTS = {
   orgTypeListEndPoint: `${CONSTANTS.KONG_API_BASE}/data/v1/system/settings/get/orgTypeList`,
 }
 export const proxiesV8 = express.Router()
+
+// Route-level body parsing — runs after keycloak.protect so unauthenticated
+// requests are rejected before spending CPU on JSON deserialization.
+proxiesV8.use(express.json({ limit: '50mb' }))
+proxiesV8.use(express.urlencoded({ extended: false, limit: '50mb' }))
+
 const _ = require('lodash')
 
 const FILE_NOT_FOUND_ERR = 'File not found in the request'

--- a/src/publicApi_v8/publicApiV8.ts
+++ b/src/publicApi_v8/publicApiV8.ts
@@ -15,6 +15,11 @@ import { youtubePlaylist } from './youtubePlaylist'
 const puppeteer = require('puppeteer')
 export const publicApiV8 = express.Router()
 
+// Route-level body parsing — publicApiV8 is mounted before global body parsers
+// (which run after keycloak auth). Public routes that use req.body need this.
+publicApiV8.use(express.json({ limit: '50mb' }))
+publicApiV8.use(express.urlencoded({ extended: false, limit: '50mb' }))
+
 const API_END_POINTS = {
   designationSearch: `${CONSTANTS.KONG_API_BASE}/designation/search`,
   kongCompositeSearch: `${CONSTANTS.KONG_API_BASE}/composite/v4/search`,

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,8 +48,6 @@ export class Server {
     }
     const sessionConfig = getSessionConfig()
     this.app.use(expressSession(sessionConfig))
-    this.app.use(express.urlencoded({ extended: false, limit: '50mb' }))
-    this.app.use(express.json({ limit: '50mb' }))
     this.setCookie()
     this.app.all('*', apiWhiteListLogger())
     if (CONSTANTS.PORTAL_API_WHITELIST_CHECK === 'true') {
@@ -58,6 +56,10 @@ export class Server {
     this.setKeyCloak(sessionConfig)
     this.authoringProxies()
     this.setExtFormsFramework()
+    // No global body parsers — each router has its own so that keycloak.protect
+    // rejects unauthenticated requests before body parsing runs.
+    // Public routes, authApi, protectedApiV8, and proxiesV8 each register
+    // express.json() and express.urlencoded() at router level.
     this.servePublicApi()
     this.configureMiddleware()
     this.serverProtectedApi()

--- a/tests/test-body-parse-order.mjs
+++ b/tests/test-body-parse-order.mjs
@@ -1,0 +1,96 @@
+/**
+ * Test: body parsing runs after auth — unauthenticated requests skip parsing.
+ *
+ * Simulates the server.ts middleware order: keycloak.protect on routes,
+ * body parsers inside routers (not global).
+ *
+ * Run: node tests/test-body-parse-order.mjs
+ */
+
+import http from 'node:http'
+import assert from 'node:assert/strict'
+import express from 'express'
+
+const PORT = 19897
+
+const app = express()
+
+// --- Mock keycloak protect: reject if no Authorization header ---
+function mockKeycloakProtect(req, res, next) {
+  if (!req.headers.authorization || req.headers.authorization !== 'Bearer valid-token') {
+    res.status(401).json({ error: 'Unauthorized', bodyWasParsed: !!req._body })
+    return
+  }
+  next()
+}
+
+// --- Public router with its own body parser ---
+const publicRouter = express.Router()
+publicRouter.use(express.json({ limit: '50mb' }))
+publicRouter.post('/search', (req, res) => {
+  res.json({ parsed: !!req._body, body: req.body })
+})
+app.use('/public/v8', publicRouter)
+
+// --- Protected router: body parser INSIDE router, keycloak.protect on mount ---
+const protectedRouter = express.Router()
+protectedRouter.use(express.json({ limit: '50mb' }))
+protectedRouter.post('/user', (req, res) => {
+  res.json({ parsed: !!req._body, body: req.body })
+})
+app.use('/protected/v8', mockKeycloakProtect, protectedRouter)
+
+// NO global body parser — matches the new server.ts layout
+
+const server = await new Promise(resolve => {
+  const s = app.listen(PORT, () => resolve(s))
+})
+
+function post(path, body, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body)
+    const req = http.request({
+      hostname: '127.0.0.1', port: PORT, path, method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data), ...headers },
+    }, (res) => {
+      let respBody = ''
+      res.on('data', c => respBody += c)
+      res.on('end', () => resolve({ status: res.statusCode, body: JSON.parse(respBody) }))
+    })
+    req.on('error', reject)
+    req.write(data)
+    req.end()
+  })
+}
+
+// =========================================================
+// Test 1: Unauthenticated → protected route — rejected, body NOT parsed
+// =========================================================
+const r1 = await post('/protected/v8/user', { name: 'test' })
+assert.equal(r1.status, 401, 'Should be rejected')
+assert.equal(r1.body.bodyWasParsed, false, 'Body should NOT be parsed before auth rejection')
+console.log('✅ Unauthenticated protected request: rejected without body parsing')
+
+// =========================================================
+// Test 2: Authenticated → protected route — body parsed after auth
+// =========================================================
+const r2 = await post('/protected/v8/user', { name: 'test' }, { Authorization: 'Bearer valid-token' })
+assert.equal(r2.status, 200, 'Should succeed')
+assert.equal(r2.body.parsed, true, 'Body should be parsed')
+assert.equal(r2.body.body.name, 'test', 'Body content should match')
+console.log('✅ Authenticated protected request: body parsed correctly')
+
+// =========================================================
+// Test 3: Public route — body parsed without auth
+// =========================================================
+const r3 = await post('/public/v8/search', { query: 'hello' })
+assert.equal(r3.status, 200, 'Should succeed')
+assert.equal(r3.body.parsed, true, 'Body should be parsed by route-level parser')
+assert.equal(r3.body.body.query, 'hello', 'Body content should match')
+console.log('✅ Public route: body parsed without auth')
+
+// =========================================================
+console.log(`\n${'─'.repeat(50)}`)
+console.log('✅ ALL PASS — body parsing skipped for unauthenticated requests')
+
+server.close()


### PR DESCRIPTION
express.json() and express.urlencoded() were running before auth, parsing the body of every request including unauthenticated ones. Now keycloak rejects invalid requests first. Public routes and authApi get their own route-level body parsers with a tighter 1mb limit.

 Before: One global body parser registered early in the middleware chain.

 ```
   Request arrives
     → session, cookies, whitelist
     → keycloak.middleware (just initializes, doesn't reject)
     → express.json() ← PARSES BODY FOR EVERYONE
     → route matched: /protected/v8 → keycloak.protect → reject 401
 ```

 Every request gets its body parsed — even if it's about to be rejected as
 unauthenticated. That's wasted CPU.

 After: No global body parser. Each router has its own parser inside it.

 ```
   Request arrives
     → session, cookies, whitelist
     → keycloak.middleware
     → route matched: /protected/v8 → keycloak.protect → reject 401 (no parsing
 happened)
 ```

 ```
   Authenticated request arrives
     → session, cookies, whitelist
     → keycloak.middleware
     → route matched: /protected/v8 → keycloak.protect → PASSES
       → express.json() inside router ← PARSES ONLY NOW
       → handler gets req.body
 ```
