### PR TITLE
4.8.35 dev v3 fix http empty request body

### DIFF
--- a/src/authoring/authBackend.ts
+++ b/src/authoring/authBackend.ts
@@ -1,9 +1,9 @@
 import express from 'express'
-import { createProxyServer } from 'http-proxy'
 import { CONSTANTS } from '../utils/env'
+import { createPooledProxy } from '../utils/proxyCreator'
 
 export const authBackend = express.Router()
-const proxyCreator = createProxyServer()
+const proxyCreator = createPooledProxy()
 
 authBackend.all('*', (req, res) => {
   req.url = req.url.replace('/authApi', '')

--- a/src/authoring/authContent.ts
+++ b/src/authoring/authContent.ts
@@ -1,11 +1,11 @@
 import axios from 'axios'
 import express from 'express'
-import { createProxyServer } from 'http-proxy'
 import { axiosRequestConfig } from '../configs/request.config'
 import { CONSTANTS } from '../utils/env'
+import { createPooledProxy } from '../utils/proxyCreator'
 
 const GENERAL_ERROR_MSG = 'Failed due to unknown reason'
-const proxyCreator = createProxyServer()
+const proxyCreator = createPooledProxy()
 const contentStoreApi = '/contentv3/download/'
 export const authContent = express.Router()
 

--- a/src/authoring/authIapBackend.ts
+++ b/src/authoring/authIapBackend.ts
@@ -1,9 +1,9 @@
 import express from 'express'
-import { createProxyServer } from 'http-proxy'
 import { CONSTANTS } from '../utils/env'
+import { createPooledProxy } from '../utils/proxyCreator'
 
 export const authIapBackend = express.Router()
-const proxyCreator = createProxyServer()
+const proxyCreator = createPooledProxy()
 
 authIapBackend.all('*', (req, res) => {
   req.url = req.url.replace('/authIapApi', '')

--- a/src/authoring/authNotification.ts
+++ b/src/authoring/authNotification.ts
@@ -1,9 +1,9 @@
 import express from 'express'
-import { createProxyServer } from 'http-proxy'
 import { CONSTANTS } from '../utils/env'
+import { createPooledProxy } from '../utils/proxyCreator'
 
 export const authNotification = express.Router()
-const proxyCreator = createProxyServer({ timeout: 10000 })
+const proxyCreator = createPooledProxy({ timeout: 10000 })
 
 authNotification.all('*', (req, res) => {
   req.url = req.url.replace('/authNotificationApi', '')

--- a/src/configs/request.config.ts
+++ b/src/configs/request.config.ts
@@ -17,6 +17,8 @@ const sharedHttpsAgent = new https.Agent({
   timeout: CONSTANTS.UPSTREAM_KEEPALIVE_TIMEOUT,
 })
 
+export { sharedHttpAgent, sharedHttpsAgent }
+
 export const axiosRequestConfig: AxiosRequestConfig = {
   httpAgent: sharedHttpAgent,
   httpsAgent: sharedHttpsAgent,

--- a/src/utils/proxyCreator.ts
+++ b/src/utils/proxyCreator.ts
@@ -13,7 +13,7 @@ function pickAgent(target: string) {
 }
 
 /** Wrap createProxyServer so every .web() call auto-injects the right keep-alive agent */
-function createPooledProxy(opts: Record<string, any> = {}) {
+export function createPooledProxy(opts: Record<string, any> = {}) {
   const instance = createProxyServer(opts)
   const originalWeb = instance.web.bind(instance)
   // tslint:disable-next-line: no-any

--- a/src/utils/proxyCreator.ts
+++ b/src/utils/proxyCreator.ts
@@ -1,20 +1,40 @@
 import { Router } from 'express'
 import { createProxyServer } from 'http-proxy'
+import { sharedHttpAgent, sharedHttpsAgent } from '../configs/request.config'
 import { extractUserEmailFromRequest, extractUserId, extractUserToken } from '../utils/requestExtract'
 import { CONSTANTS } from './env'
 import { logDebug, logError } from './logger'
 
 const _ = require('lodash')
 
+/** Pick the correct keep-alive agent based on target protocol */
+function pickAgent(target: string) {
+  return target.startsWith('https') ? sharedHttpsAgent : sharedHttpAgent
+}
+
+/** Wrap createProxyServer so every .web() call auto-injects the right keep-alive agent */
+function createPooledProxy(opts: Record<string, any> = {}) {
+  const instance = createProxyServer(opts)
+  const originalWeb = instance.web.bind(instance)
+  // tslint:disable-next-line: no-any
+  instance.web = (req: any, res: any, options: any = {}, ...args: any[]) => {
+    const target = options.target || ''
+    options.agent = pickAgent(typeof target === 'string' ? target : '')
+    return originalWeb(req, res, options, ...args)
+  }
+  return instance
+}
+
 // Singleton proxy — no timeout (used by 14 existing functions)
-const proxy = createProxyServer({})
+const proxy = createPooledProxy({})
 
 // Singleton proxy with timeout — replaces per-request factory (used by 10 routes)
 // Previously: const proxyCreator = (timeout) => createProxyServer({ timeout }) — leaked instances
 // TODO: This is a temporary workaround to prevent unbounded proxy object creation.
 // Proper fix: evaluate if these routes can use the main singleton proxy with a
 // timeout, or migrate to axios streaming, eliminating the need for http-proxy here.
-const proxyTimed = createProxyServer({ timeout: CONSTANTS.PROXY_TIMEOUT })
+const proxyTimed = createPooledProxy({ timeout: CONSTANTS.PROXY_TIMEOUT })
+
 const PROXY_SLUG = '/proxies/v8'
 const PROXY_SLUG_WAT = '/proxies/v8/wat'
 const PROXY_SLUG_FORMS = '/proxies/v8/ext-forms'

--- a/src/utils/proxyCreator.ts
+++ b/src/utils/proxyCreator.ts
@@ -1,11 +1,60 @@
 import { Router } from 'express'
 import { createProxyServer } from 'http-proxy'
+import { Readable } from 'stream'
 import { sharedHttpAgent, sharedHttpsAgent } from '../configs/request.config'
 import { extractUserEmailFromRequest, extractUserId, extractUserToken } from '../utils/requestExtract'
 import { CONSTANTS } from './env'
 import { logDebug, logError } from './logger'
 
 const _ = require('lodash')
+
+/** Upload paths that must not have their body re-serialised (binary streams) */
+const UPLOAD_EXCLUSIONS = ['/storage/upload', '/storage/profilePhotoUpload/']
+const DISCUSSION_PATH = '/discussion'
+const DISCUSSION_CREATE_PATH = '/discussion/user/v1/create'
+
+/**
+ * Build a Readable stream from req.body for use as http-proxy's options.buffer.
+ *
+ * Why: http-proxy fires the 'proxyReq' event via the 'socket' event. When a
+ * keep-alive agent queues a request (no free socket), the empty pipe from the
+ * already-consumed req stream completes before the socket is assigned, flushing
+ * headers + EOF. The proxyReq event fires too late — setHeader/write throws
+ * ERR_HTTP_HEADERS_SENT. Passing a buffer stream bypasses this entirely: http-proxy
+ * pipes options.buffer instead of the consumed req, delivering the body regardless
+ * of socket timing.
+ *
+ * Returns undefined for GETs, empty bodies, and upload paths (binary streams).
+ */
+  // tslint:disable-next-line: no-any
+export function buildProxyBuffer(req: any): Readable | undefined {
+  // No body to re-serialise
+  if (!req.body || typeof req.body !== 'object' || Object.keys(req.body).length === 0) {
+    if (req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH') {
+      logWarn(`buildProxyBuffer: ${req.method} ${req.originalUrl || req.url} has empty/missing req.body`)
+    }
+    return undefined
+  }
+
+  // Upload routes — preserve raw binary stream
+  const url = req.originalUrl || req.url || ''
+  if (UPLOAD_EXCLUSIONS.some((exc) => url.includes(exc))) {
+    return undefined
+  }
+
+  const bodyData = JSON.stringify(req.body)
+  const byteLength = Buffer.byteLength(bodyData)
+
+  // Set content-length on req.headers so setupOutgoing copies it into the outgoing request
+  req.headers['content-length'] = String(byteLength)
+  // Remove transfer-encoding if present — we have an explicit content-length
+  delete req.headers['transfer-encoding']
+
+  const stream = new Readable({ read() { /* noop */ } })
+  stream.push(bodyData)
+  stream.push(null)
+  return stream
+}
 
 /** Pick the correct keep-alive agent based on target protocol */
 function pickAgent(target: string) {
@@ -39,52 +88,63 @@ const PROXY_SLUG = '/proxies/v8'
 const PROXY_SLUG_WAT = '/proxies/v8/wat'
 const PROXY_SLUG_FORMS = '/proxies/v8/ext-forms'
 
+/**
+ * Express middleware: injects upstream auth/routing headers onto req.headers
+ * BEFORE proxy.web() is called. setupOutgoing() copies req.headers into the
+ * outgoing request before socket assignment, so there is no race condition
+ * with keep-alive agent socket timing.
+ *
+ * Replaces the old proxy.on('proxyReq') header injection which threw
+ * ERR_HTTP_HEADERS_SENT when the agent queued the request.
+ */
 // tslint:disable-next-line: no-any
-proxy.on('proxyReq', (proxyReq: any, req: any, _res: any, _options: any) => {
-  logDebug('proxyReqOn method. Adding more headers in request...')
-  const rootOrg = req.headers ? req.headers.rootOrg : req.headers.rootorg
-  logDebug(`rootOrg is updated: ` + JSON.stringify(rootOrg))
+export function proxyHeaders(req: any, _res: any, next: any) {
+  const session = req.session || {}
+  const rootOrgId = session.rootOrgId || ''
+  const channel = session.channel || ''
+
   // tslint:disable-next-line: no-duplicate-string
-  proxyReq.setHeader('X-Channel-Id', (_.get(req, 'session.rootOrgId')) ? _.get(req, 'session.rootOrgId') : CONSTANTS.X_Channel_Id)
-  // tslint:disable-next-line: max-line-length
-  proxyReq.setHeader('Authorization', CONSTANTS.SB_API_KEY)
-  proxyReq.setHeader('x-authenticated-user-token', extractUserToken(req))
-  proxyReq.setHeader('x-authenticated-userid', extractUserId(req))
-  let rootOrgId = ''
-  if (req.session.hasOwnProperty('rootOrgId')) {
-    rootOrgId = req.session.rootOrgId
-  }
-  proxyReq.setHeader('x-authenticated-user-orgid', rootOrgId)
-  let userRoles = []
-  if (req.session.hasOwnProperty('userRoles')) {
-      userRoles = req.session.userRoles
-  }
-  proxyReq.setHeader('x-authenticated-user-roles', userRoles)
-  let channel = ''
-  if (req.session.hasOwnProperty('channel')) {
-    channel = req.session.channel
-  }
-  proxyReq.setHeader('x-authenticated-user-orgname', channel)
-  proxyReq.setHeader('x-authenticated-user-channel', channel)
-  if (req.session.hasOwnProperty('uid')) {
-    proxyReq.setHeader('x-authenticated-user-nodebb-uid', req.session.uid)
+  req.headers['x-channel-id'] = rootOrgId || CONSTANTS.X_Channel_Id
+  req.headers.authorization = CONSTANTS.SB_API_KEY
+  req.headers['x-authenticated-user-token'] = extractUserToken(req)
+  req.headers['x-authenticated-userid'] = extractUserId(req)
+  req.headers['x-authenticated-user-orgid'] = rootOrgId
+  req.headers['x-authenticated-user-roles'] = String(session.userRoles || [])
+  req.headers['x-authenticated-user-orgname'] = channel
+  req.headers['x-authenticated-user-channel'] = channel
+
+  if (session.uid) {
+    req.headers['x-authenticated-user-nodebb-uid'] = session.uid
   }
 
-  // condition has been added to set the session in nodebb req header
-  /* tslint:disable-next-line */
-  if (req.originalUrl.includes('/discussion') && !req.originalUrl.includes('/discussion/user/v1/create') && req.session) {
-    if (req.session) {
-      req.sesson.cookie.secure = true
-    }
-    if (req.body && req.session.hasOwnProperty('uid')) {
-      req.body._uid = req.session.uid
-    }
-    logDebug('REQ_URL_ORIGINAL discussion', proxyReq.path)
+  // Discussion route: set secure cookie + inject _uid into body
+  setDiscussionFields(req, session)
+
+  next()
+}
+
+// tslint:disable-next-line: no-any
+function setDiscussionFields(req: any, session: any) {
+  const url = req.originalUrl || ''
+  if (!url.includes(DISCUSSION_PATH) || url.includes(DISCUSSION_CREATE_PATH)) {
+    return
   }
-  if (!req.originalUrl.includes('/storage/upload') && !req.originalUrl.includes('/storage/profilePhotoUpload/*') && req.body) {
-    const bodyData = JSON.stringify(req.body)
-    proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData))
-    proxyReq.write(bodyData)
+  if (session.cookie) {
+    session.cookie.secure = true
+  }
+  // Body mutation: inject _uid — must happen before buildProxyBuffer
+  if (req.body && session.uid) {
+    req.body._uid = session.uid
+  }
+}
+
+// Minimal proxyReq handler — only logging, wrapped in try/catch to prevent uncaughtException
+// tslint:disable-next-line: no-any
+proxy.on('proxyReq', (_proxyReq: any, req: any, _res: any, _options: any) => {
+  try {
+    logInfo('proxyReq →', req.method, req.originalUrl || req.url)
+  } catch (err) {
+    logError('proxyReq event error:', String(err))
   }
 })
 
@@ -115,7 +175,7 @@ proxy.on('proxyRes', (proxyRes: any, req: any, _res: any, ) => {
   // }
   // tslint:disable-next-line: no-any
   proxyRes.on('data', (data: any) => {
-    if (req.originalUrl.includes('/discussion/user/v1/create')) {
+    if (req.originalUrl.includes(DISCUSSION_CREATE_PATH)) {
 
       if ((proxyRes.statusCode === 200 || proxyRes.statusCode === 201)) {
         data = JSON.parse(data.toString('utf-8'))
@@ -131,10 +191,27 @@ proxy.on('proxyRes', (proxyRes: any, req: any, _res: any, ) => {
 
 })
 
+/** Snapshot of agent pool for diagnostics */
+function poolStats(): string {
+  // tslint:disable-next-line: no-any
+  const agent: any = sharedHttpAgent
+  const key = Object.keys(agent.sockets || {})[0] || ''
+  if (!key) { return 'pool: empty' }
+  const active = (agent.sockets[key] || []).length
+  const free = ((agent.freeSockets || {})[key] || []).length
+  const queued = ((agent.requests || {})[key] || []).length
+  return `pool: active=${active} free=${free} queued=${queued}`
+}
+
 // Error handler — return 502 instead of crashing or hanging the connection
 // tslint:disable-next-line: no-any
 function handleProxyError(err: any, req: any, res: any) {
-  logError('Proxy error:', String(err.message || err), '| url:', req.originalUrl || req.url)
+  const code = err.code || 'UNKNOWN'
+  logError(
+    `Proxy error: ${code} ${String(err.message || err)}`,
+    `| ${req.method} ${req.originalUrl || req.url}`,
+    `| ${poolStats()}`
+  )
   if (res && !res.headersSent) {
     res.writeHead(502, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ error: 'Bad Gateway', message: 'Upstream service unavailable' }))
@@ -144,8 +221,18 @@ function handleProxyError(err: any, req: any, res: any) {
 proxy.on('error', handleProxyError)
 proxyTimed.on('error', handleProxyError)
 
+// Log connection resets with request context instead of silently swallowing
+// tslint:disable-next-line: no-any
+proxy.on('econnreset', (err: any, req: any, _res: any, _target: any) => {
+  logError(`Proxy ECONNRESET: ${req.method} ${req.originalUrl || req.url}`, String(err.message || err))
+})
+// tslint:disable-next-line: no-any
+proxyTimed.on('econnreset', (err: any, req: any, _res: any, _target: any) => {
+  logError(`Proxy ECONNRESET: ${req.method} ${req.originalUrl || req.url}`, String(err.message || err))
+})
+
 export function proxyCreatorRoute(route: Router, targetUrl: string, _timeout = 10000): Router {
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
     const downloadKeyword = '/download/'
     if (req.url.startsWith(downloadKeyword)) {
       req.url = downloadKeyword + req.url.split(downloadKeyword)[1].replace(/\//g, '%2F')
@@ -153,6 +240,7 @@ export function proxyCreatorRoute(route: Router, targetUrl: string, _timeout = 1
     logDebug('REQ_URL_ORIGINAL', req.originalUrl)
     logDebug('REQ_URL', req.url)
     proxyTimed.web(req, res, {
+      buffer: buildProxyBuffer(req),
       target: targetUrl,
     })
   })
@@ -160,8 +248,9 @@ export function proxyCreatorRoute(route: Router, targetUrl: string, _timeout = 1
 }
 
 export function ilpProxyCreatorRoute(route: Router, baseUrl: string): Router {
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
     proxyTimed.web(req, res, {
+      buffer: buildProxyBuffer(req),
       headers: { ...req.headers } as { [s: string]: string },
       target: baseUrl + req.url,
     })
@@ -170,8 +259,9 @@ export function ilpProxyCreatorRoute(route: Router, baseUrl: string): Router {
 }
 
 export function scormProxyCreatorRoute(route: Router, baseUrl: string): Router {
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
     proxyTimed.web(req, res, {
+      buffer: buildProxyBuffer(req),
       target: baseUrl,
     })
   })
@@ -179,11 +269,12 @@ export function scormProxyCreatorRoute(route: Router, baseUrl: string): Router {
 }
 
 export function proxyCreatorLearner(route: Router, targetUrl: string, _timeout = 10000): Router {
-  route.all('/*', (req, res) => {
-    logDebug('REQ_URL_ORIGINAL proxyCreatorLearner', req.originalUrl)
+  route.all('/*', proxyHeaders, (req, res) => {
+    logInfo('REQ_URL_ORIGINAL proxyCreatorLearner', req.originalUrl)
     const url = removePrefix(`${PROXY_SLUG}/learner`, req.originalUrl)
     logDebug('Final URL: ', targetUrl + url)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: targetUrl + url,
@@ -193,8 +284,8 @@ export function proxyCreatorLearner(route: Router, targetUrl: string, _timeout =
 }
 // tslint:disable-next-line
 export function proxyCreatorSunbird(route: Router, targetUrl: string, _timeout = 10000): Router {
-  route.all('/*', (req, res) => {
-    logDebug('REQ_URL_ORIGINAL proxyCreatorSunbird', req.originalUrl)
+  route.all('/*', proxyHeaders, (req, res) => {
+    logInfo('REQ_URL_ORIGINAL proxyCreatorSunbird', req.originalUrl)
     let url = ''
     if (req.originalUrl.includes('/proxies/v8/wat')) {
       url = removePrefix(`${PROXY_SLUG_WAT}`, req.originalUrl)
@@ -202,7 +293,7 @@ export function proxyCreatorSunbird(route: Router, targetUrl: string, _timeout =
       url = removePrefix(`${PROXY_SLUG}`, req.originalUrl)
     }
 
-    if (req.originalUrl.includes('/discussion') && !req.originalUrl.includes('/discussion/user/v1/create') && req.session) {
+    if (req.originalUrl.includes(DISCUSSION_PATH) && !req.originalUrl.includes(DISCUSSION_CREATE_PATH) && req.session) {
       if (req.session.hasOwnProperty('uid')) {
         if (req.originalUrl.includes('?')) {
           url = `${url}&_uid=${req.session.uid}`
@@ -226,6 +317,7 @@ export function proxyCreatorSunbird(route: Router, targetUrl: string, _timeout =
     }
 
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: targetUrl + url,
@@ -235,11 +327,12 @@ export function proxyCreatorSunbird(route: Router, targetUrl: string, _timeout =
 }
 
 export function proxyCreatorKnowledge(route: Router, targetUrl: string, _timeout = 10000): Router {
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
 
     const url = removePrefix(`${PROXY_SLUG}`, req.originalUrl)
     logDebug('REQ_URL_ORIGINAL proxyCreatorKnowledge', targetUrl + url)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: targetUrl + url,
@@ -249,10 +342,11 @@ export function proxyCreatorKnowledge(route: Router, targetUrl: string, _timeout
 }
 
 export function proxyCreatorUpload(route: Router, targetUrl: string, _timeout = 10000): Router {
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
     const url = removePrefix(`${PROXY_SLUG}/action`, req.originalUrl)
     logDebug('REQ_URL_ORIGINAL proxyCreatorUpload', targetUrl)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: targetUrl + url,
@@ -266,9 +360,10 @@ function removePrefix(prefix: string, s: string) {
 }
 
 export function proxyCreatorSunbirdSearch(route: Router, targetUrl: string, _timeout = 10000): Router {
-  route.all('/*', (req, res) => {
-    logDebug('REQ_URL_ORIGINAL proxyCreatorSunbirdSearch', req.originalUrl)
+  route.all('/*', proxyHeaders, (req, res) => {
+    logInfo('REQ_URL_ORIGINAL proxyCreatorSunbirdSearch', req.originalUrl)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: targetUrl,
@@ -278,7 +373,7 @@ export function proxyCreatorSunbirdSearch(route: Router, targetUrl: string, _tim
 }
 
 export function proxyCreatorToAppentUserId(route: Router, targetUrl: string, _timeout = 10000): Router {
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
     const originalUrl = req.originalUrl
     const lastIndex = originalUrl.lastIndexOf('/')
     const subStr = originalUrl.substr(lastIndex).substr(1).split('-').length
@@ -288,6 +383,7 @@ export function proxyCreatorToAppentUserId(route: Router, targetUrl: string, _ti
     }
     logDebug('REQ_URL_ORIGINAL proxyCreatorToAppentUserId', req.originalUrl)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: targetUrl + userId, // [userId.length - 1],
@@ -297,11 +393,12 @@ export function proxyCreatorToAppentUserId(route: Router, targetUrl: string, _ti
 }
 
 export function proxyCreatorQML(route: Router, targetUrl: string, urlType: string, _timeout = 10000, ): Router {
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
     const originalUrl = req.originalUrl.replace(urlType, '/')
     const url = removePrefix(`${PROXY_SLUG}`, originalUrl)
     logDebug('REQ_URL_ORIGINAL proxyCreatorQML', targetUrl + url)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: targetUrl + url,
@@ -311,10 +408,11 @@ export function proxyCreatorQML(route: Router, targetUrl: string, urlType: strin
 }
 
 export function proxyContent(route: Router, targetUrl: string, _timeout = 10000): Router {
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
     const url = removePrefix(`${PROXY_SLUG}/private`, req.originalUrl)
     logDebug('REQ_URL_ORIGINAL proxyCreatorUpload', targetUrl)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: targetUrl + url,
@@ -324,10 +422,11 @@ export function proxyContent(route: Router, targetUrl: string, _timeout = 10000)
 }
 
 export function proxyContentLearnerVM(route: Router, targetUrl: string, _timeout = 10000): Router {
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
     const url = removePrefix(`${PROXY_SLUG}/learnervm/private`, req.originalUrl)
     logDebug('REQ_URL_ORIGINAL proxyContentLearnerVM', targetUrl)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: targetUrl + url,
@@ -338,7 +437,7 @@ export function proxyContentLearnerVM(route: Router, targetUrl: string, _timeout
 
 export function proxyAssessmentRead(route: Router, targetUrl: string, _timeout = 10000): Router {
   const hierarchyQuery = 'hierarchy=detail'
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
     let url = removePrefix(`${PROXY_SLUG}/assessment/read`, req.originalUrl)
     // Check if the target URL already contains query parameters
     url = url.includes('?')
@@ -346,6 +445,7 @@ export function proxyAssessmentRead(route: Router, targetUrl: string, _timeout =
       : `${targetUrl}${url}?${hierarchyQuery}`
     logDebug('REQ_URL_UPDATED proxyAssessmentRead', url)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: url,
@@ -355,7 +455,7 @@ export function proxyAssessmentRead(route: Router, targetUrl: string, _timeout =
 }
 
 export function proxyQuestionRead(route: Router, targetUrl: string, _timeout = 10000): Router {
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
     if (!targetUrl.includes('?')) {
     // Split the URL into base URL and query parameters
     const [, queryParams] = req.originalUrl.split('?')
@@ -364,6 +464,7 @@ export function proxyQuestionRead(route: Router, targetUrl: string, _timeout = 1
     }
     logDebug('REQ_URL_UPDATED proxyAssessmentRead', targetUrl)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: targetUrl,
@@ -373,11 +474,12 @@ export function proxyQuestionRead(route: Router, targetUrl: string, _timeout = 1
 }
 
 export function proxyCreatorForms(route: Router, _timeout = 10000): Router {
-  route.all('/*', (req, res) => {
-    logDebug('REQ_URL_ORIGINAL proxyCreatorSunbird', req.originalUrl)
+  route.all('/*', proxyHeaders, (req, res) => {
+    logInfo('REQ_URL_ORIGINAL proxyCreatorSunbird', req.originalUrl)
     let url = ''
     url = removePrefix(`${PROXY_SLUG_FORMS}`, req.originalUrl)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       target: 'http://localhost:3003/' + url,
     })
   })
@@ -385,7 +487,7 @@ export function proxyCreatorForms(route: Router, _timeout = 10000): Router {
 }
 
 export function proxyAssessmentReadV2(route: Router, targetUrl: string, _timeout = 10000): Router {
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
     let url = removePrefix(`${PROXY_SLUG}/assessment/v5/read`, req.originalUrl)
     // Check if the target URL already contains query parameters
     if (url.includes('?')) {
@@ -395,6 +497,7 @@ export function proxyAssessmentReadV2(route: Router, targetUrl: string, _timeout
     }
     logDebug('REQ_URL_UPDATED proxyAssessmentReadV5', url)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: url,
@@ -405,7 +508,7 @@ export function proxyAssessmentReadV2(route: Router, targetUrl: string, _timeout
 
 export function proxyAssessmentReadV7(route: Router, targetUrl: string, _timeout = 10000): Router {
   const hierarchyQuery = 'hierarchy=detail'
-  route.all('/*', (req, res) => {
+  route.all('/*', proxyHeaders, (req, res) => {
     let url = removePrefix(`${PROXY_SLUG}/assessment/v7/read`, req.originalUrl)
     // Append query parameter
     url = url.includes('?')
@@ -413,6 +516,7 @@ export function proxyAssessmentReadV7(route: Router, targetUrl: string, _timeout
       : `${targetUrl}${url}?${hierarchyQuery}`
     logDebug('REQ_URL_UPDATED proxyAssessmentReadV7', url)
     proxy.web(req, res, {
+      buffer: buildProxyBuffer(req),
       changeOrigin: true,
       ignorePath: true,
       target: url,

--- a/tests/test-proxy-keepalive-body.mjs
+++ b/tests/test-proxy-keepalive-body.mjs
@@ -1,0 +1,152 @@
+/**
+ * Integration test: Verify POST body forwarding with keep-alive agent.
+ *
+ * Proves the fix for the http-proxy race condition where queued requests
+ * (keep-alive agent pool exhausted) lost their POST body.
+ *
+ * Tests:
+ *  1. POST with keep-alive agent → body arrives at upstream
+ *  2. GET  with keep-alive agent → response returned
+ *  3. Concurrent POSTs exceeding maxSockets → all bodies delivered
+ *
+ * Run: node tests/test-proxy-keepalive-body.mjs
+ */
+
+import http from 'node:http'
+import { Readable } from 'node:stream'
+import httpProxy from 'http-proxy'
+const { createProxyServer } = httpProxy
+
+const TIMEOUT_MS = 10000
+let exitCode = 0
+let testsRun = 0
+let testsPassed = 0
+
+function assert(condition, msg) {
+  testsRun++
+  if (condition) {
+    testsPassed++
+    console.log(`  ✅ ${msg}`)
+  } else {
+    exitCode = 1
+    console.log(`  ❌ ${msg}`)
+  }
+}
+
+/**
+ * Replicates the fix: build a Readable buffer from parsed body.
+ * Mirrors buildProxyBuffer() in proxyCreator.ts.
+ */
+function buildProxyBuffer(req) {
+  if (!req.body || typeof req.body !== 'object' || Object.keys(req.body).length === 0) {
+    return undefined
+  }
+  const bodyData = JSON.stringify(req.body)
+  req.headers['content-length'] = String(Buffer.byteLength(bodyData))
+  delete req.headers['transfer-encoding']
+  const stream = new Readable({ read() {} })
+  stream.push(bodyData)
+  stream.push(null)
+  return stream
+}
+
+async function runTests() {
+  // --- Upstream: echoes back body ---
+  const upstream = http.createServer((req, res) => {
+    let body = ''
+    req.on('data', (d) => body += d)
+    const timer = setTimeout(() => {
+      res.writeHead(504)
+      res.end(JSON.stringify({ error: 'body timeout', received: body.length }))
+    }, 3000)
+    req.on('end', () => {
+      clearTimeout(timer)
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ method: req.method, bodyLength: body.length, body, cl: req.headers['content-length'] }))
+    })
+  })
+
+  await new Promise(r => upstream.listen(0, r))
+  const upPort = upstream.address().port
+
+  // --- Proxy with keep-alive agent, maxSockets=1 to force queueing ---
+  const agent = new http.Agent({ keepAlive: true, maxSockets: 1 })
+  const proxy = createProxyServer({})
+  proxy.on('error', (err, _req, res) => {
+    if (res && !res.headersSent) { res.writeHead(502); res.end('proxy error: ' + err.message) }
+  })
+
+  // --- App: parses body, then proxies with buffer (the fix) ---
+  const app = http.createServer((req, res) => {
+    let raw = ''
+    req.on('data', (d) => raw += d)
+    req.on('end', () => {
+      if (raw) { try { req.body = JSON.parse(raw) } catch (_e) { /* noop */ } }
+      proxy.web(req, res, {
+        target: `http://127.0.0.1:${upPort}`,
+        agent,
+        buffer: buildProxyBuffer(req),
+      })
+    })
+  })
+
+  await new Promise(r => app.listen(0, r))
+  const appPort = app.address().port
+
+  function makeRequest(method, path, body) {
+    return new Promise((resolve, reject) => {
+      const headers = { 'content-type': 'application/json' }
+      const bodyStr = body ? JSON.stringify(body) : undefined
+      if (bodyStr) { headers['content-length'] = String(Buffer.byteLength(bodyStr)) }
+      const req = http.request({ host: '127.0.0.1', port: appPort, method, path, headers }, (res) => {
+        let data = ''
+        res.on('data', (d) => data += d)
+        res.on('end', () => {
+          try { resolve({ status: res.statusCode, data: JSON.parse(data) }) }
+          catch (_e) { resolve({ status: res.statusCode, data }) }
+        })
+      })
+      req.on('error', reject)
+      if (bodyStr) { req.write(bodyStr) }
+      req.end()
+    })
+  }
+
+  // --- Test 1: Single POST with keep-alive ---
+  console.log('\nTest 1: POST with keep-alive agent')
+  const r1 = await makeRequest('POST', '/test-single', { search: 'hello' })
+  assert(r1.status === 200, `status 200 (got ${r1.status})`)
+  assert(r1.data.bodyLength > 0, `body arrived (${r1.data.bodyLength} bytes)`)
+  assert(r1.data.body.includes('hello'), `body contains "hello"`)
+
+  // --- Test 2: GET with keep-alive ---
+  console.log('\nTest 2: GET with keep-alive agent')
+  const r2 = await makeRequest('GET', '/test-get', null)
+  assert(r2.status === 200, `status 200 (got ${r2.status})`)
+  assert(r2.data.method === 'GET', `method is GET`)
+
+  // --- Test 3: 5 concurrent POSTs with maxSockets=1 ---
+  console.log('\nTest 3: 5 concurrent POSTs (maxSockets=1, forces queueing)')
+  const concurrent = await Promise.all(
+    Array.from({ length: 5 }, (_, i) => makeRequest('POST', `/test-concurrent-${i}`, { id: i, payload: `data-${i}` }))
+  )
+  const allOk = concurrent.every(r => r.status === 200)
+  const allBodies = concurrent.every(r => r.data.bodyLength > 0)
+  assert(allOk, `all 5 returned 200 (got [${concurrent.map(r => r.status)}])`)
+  assert(allBodies, `all 5 bodies arrived (lengths: [${concurrent.map(r => r.data.bodyLength)}])`)
+  for (let i = 0; i < 5; i++) {
+    const parsed = JSON.parse(concurrent[i].data.body)
+    assert(parsed.id === i, `request ${i} body has correct id=${i}`)
+  }
+
+  // --- Cleanup ---
+  upstream.close()
+  app.close()
+  agent.destroy()
+
+  console.log(`\n${testsPassed}/${testsRun} tests passed`)
+  process.exit(exitCode)
+}
+
+setTimeout(() => { console.log('TIMEOUT'); process.exit(1) }, TIMEOUT_MS)
+runTests().catch((e) => { console.error(e); process.exit(1) })

--- a/tests/test-proxy-pooled-agent.mjs
+++ b/tests/test-proxy-pooled-agent.mjs
@@ -1,0 +1,125 @@
+/**
+ * Test: createPooledProxy auto-injects keep-alive agent
+ *
+ * Verifies that the createPooledProxy wrapper injects the correct
+ * http/https agent into .web() calls based on target protocol,
+ * enabling socket reuse instead of http-proxy's default agent:false.
+ *
+ * Run: npx tsx tests/test-proxy-pooled-agent.mjs
+ * Exit code: 0 = pass, 1 = fail
+ */
+
+import http from 'node:http'
+import assert from 'node:assert/strict'
+import httpProxy from 'http-proxy'
+
+const UPSTREAM_PORT = 19890
+const PROXY_PORT = 19891
+const REQUESTS = 30
+
+// --- Shared keep-alive agents (mirrors src/configs/request.config.ts) ---
+const sharedHttpAgent = new http.Agent({
+  keepAlive: true,
+  maxSockets: 50,
+  maxFreeSockets: 10,
+  timeout: 60000,
+})
+
+function pickAgent(target) {
+  return target.startsWith('https') ? null : sharedHttpAgent
+}
+
+function createPooledProxy(opts = {}) {
+  const instance = httpProxy.createProxyServer(opts)
+  const originalWeb = instance.web.bind(instance)
+  instance.web = (req, res, options = {}, ...args) => {
+    const target = options.target || ''
+    options.agent = pickAgent(typeof target === 'string' ? target : '')
+    return originalWeb(req, res, options, ...args)
+  }
+  return instance
+}
+
+// --- Upstream: tracks unique sockets ---
+const upstreamSockets = new Set()
+const upstream = http.createServer((req, res) => {
+  upstreamSockets.add(req.socket)
+  res.writeHead(200, { 'Content-Type': 'text/plain' })
+  res.end('ok')
+})
+await new Promise(resolve => upstream.listen(UPSTREAM_PORT, resolve))
+
+// =========================================================
+// Test 1: Default http-proxy (no agent) — many sockets
+// =========================================================
+console.log('Test 1: default http-proxy (agent: false)')
+upstreamSockets.clear()
+
+const defaultProxy = httpProxy.createProxyServer({})
+defaultProxy.on('error', () => {})
+const serverDefault = http.createServer((req, res) => {
+  defaultProxy.web(req, res, { target: `http://127.0.0.1:${UPSTREAM_PORT}` })
+})
+await new Promise(resolve => serverDefault.listen(PROXY_PORT, resolve))
+
+for (let i = 0; i < REQUESTS; i++) {
+  await new Promise((resolve, reject) => {
+    const req = http.request({ hostname: '127.0.0.1', port: PROXY_PORT, path: '/' }, (res) => {
+      res.resume()
+      res.on('end', resolve)
+    })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+const defaultSocketCount = upstreamSockets.size
+console.log(`  ${REQUESTS} requests → ${defaultSocketCount} upstream sockets`)
+assert.ok(defaultSocketCount > 1, `Expected multiple sockets, got ${defaultSocketCount}`)
+console.log(`  ⚠️  No socket reuse (connection: close)\n`)
+
+serverDefault.close()
+defaultProxy.close()
+
+// =========================================================
+// Test 2: createPooledProxy — socket reuse via agent
+// =========================================================
+console.log('Test 2: createPooledProxy (auto-injected keep-alive agent)')
+upstreamSockets.clear()
+
+const PROXY_PORT_2 = 19892
+const pooledProxy = createPooledProxy({})
+pooledProxy.on('error', () => {})
+const serverPooled = http.createServer((req, res) => {
+  pooledProxy.web(req, res, { target: `http://127.0.0.1:${UPSTREAM_PORT}` })
+})
+await new Promise(resolve => serverPooled.listen(PROXY_PORT_2, resolve))
+
+for (let i = 0; i < REQUESTS; i++) {
+  await new Promise((resolve, reject) => {
+    const req = http.request({ hostname: '127.0.0.1', port: PROXY_PORT_2, path: '/' }, (res) => {
+      res.resume()
+      res.on('end', resolve)
+    })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+const pooledSocketCount = upstreamSockets.size
+console.log(`  ${REQUESTS} requests → ${pooledSocketCount} upstream sockets`)
+assert.equal(pooledSocketCount, 1, `Expected 1 socket with keep-alive, got ${pooledSocketCount}`)
+console.log(`  ✅ Socket reused via pooled agent\n`)
+
+// =========================================================
+// Summary
+// =========================================================
+console.log('─'.repeat(50))
+console.log('✅ ALL PASS')
+console.log(`  Default http-proxy: ${REQUESTS} requests → ${defaultSocketCount} sockets (no reuse)`)
+console.log(`  Pooled http-proxy:  ${REQUESTS} requests → ${pooledSocketCount} socket  (reused)`)
+
+upstream.close()
+serverPooled.close()
+pooledProxy.close()
+sharedHttpAgent.destroy()


### PR DESCRIPTION
    Fix POST body lost with keep-alive agent due to http-proxy socket race

    http-proxy fires the proxyReq event via the socket event. When a keep-alive
    agent queues a request (pool exhausted), the empty pipe from the consumed
    req stream completes before socket assignment. Headers flush with the
    original Content-Length but zero body bytes — upstream waits forever.

    Replace proxyReq.setHeader()/write() with:
    - proxyHeaders middleware: sets auth headers on req.headers before proxy.web()
      so setupOutgoing copies them before socket assignment
    - buildProxyBuffer(req): serialises req.body into a Readable stream passed
      as options.buffer, which http-proxy pipes after socket assignment

    Also add structured error logging with agent pool stats, econnreset handler,
    and try/catch safety in residual proxyReq event handler.

    Ref: http-party/node-http-proxy#1478
